### PR TITLE
Add kitspace manifest

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,27 @@
+multi:
+  index_mobo:
+    summary: Index pick and place machine motherboard
+    eda:
+      type: kicad
+      pcb: pnp/pcb/mobo/mobo.kicad_pcb
+    bom: pnp/pcb/mobo/mobo.kicad_pcb
+    readme: README.md
+    site: https://www.youtube.com/playlist?list=PLIeJXmcg1baLBz3x0nCDqkYpKs2IWGHk4
+
+  index_piggyback:
+    summary: Index pick and place machine piggy back
+    eda:
+      type: kicad
+      pcb: pnp/pcb/piggyback/piggyback.kicad_pcb
+    bom: pnp/pcb/piggyback/bom/digikey_piggyback_bom.csv
+    readme: README.md
+    site: https://www.youtube.com/playlist?list=PLIeJXmcg1baLBz3x0nCDqkYpKs2IWGHk4
+
+  index_ringLight:
+    summary: Index pick and place machine ring light
+    eda:
+      type: kicad
+      pcb: pnp/pcb/ringLight/ringLight.kicad_pcb
+    bom: pnp/pcb/mobo/mobo.kicad_pcb
+    readme: README.md
+    site: https://www.youtube.com/playlist?list=PLIeJXmcg1baLBz3x0nCDqkYpKs2IWGHk4

--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -13,7 +13,7 @@ multi:
     eda:
       type: kicad
       pcb: pnp/pcb/piggyback/piggyback.kicad_pcb
-    bom: pnp/pcb/piggyback/bom/digikey_piggyback_bom.csv
+    bom: pnp/pcb/piggyback/piggyback.kicad_pcb
     readme: README.md
     site: https://www.youtube.com/playlist?list=PLIeJXmcg1baLBz3x0nCDqkYpKs2IWGHk4
 


### PR DESCRIPTION
Hey, this PR adds a kitspace.yaml manifest file which lets you add the project to [kitspace.org](https://kitspace.org). 

The idea of Kitspace is to make it as easy as possible to (re-)build an electronics design by automating the add-to cart functionality, providing automatic generation of an assembly guide through Interactive HTML BOM, providing easy access to the BOM, specs and Gerber files and more. 

Here are some preview of what the pages will look like:

- [mobo](http://add-index-pnp.preview.kitspace.org/boards/github.com/kitspace-forks/index/index_mobo/)
- [piggyback](http://add-index-pnp.preview.kitspace.org/boards/github.com/kitspace-forks/index/index_piggyback/)
- [ringLight](http://add-index-pnp.preview.kitspace.org/boards/github.com/kitspace-forks/index/index_ringLight/)


The BOM isn't ideal yet, if we had some .csv or excel files with the parts, digikey and/or mouser etc SKUs, and references in one then you'de get the 1-click BOM add to cart functionality. Right now I am just pulling out basic BOM info from the .kicad_pcb file actually. (The one .csv file I found for the piggyback, doesn't have any schematic references in it.)

Anyway, let me know if you are happy to add it to Kitspace. Happy to help nail down the BOM thing as well, I actually develop a tool for that called the [BOM Builder](https://kitspace.org/bom-builder/) and I can give you access if you want to try it out.