### PR TITLE
BOM Update Work

### DIFF
--- a/pnp/pcb/mobo/misc_input.sch
+++ b/pnp/pcb/mobo/misc_input.sch
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3ff7dc920bfd597ec5df8d9252b3bf043979e485b0047bcd86e5f1408135a574
-size 24941
+oid sha256:88b5aee64761c801adb182ab89c9a8ba610aae55e5e0f027a6a0c887c60790d6
+size 26206

--- a/pnp/pcb/mobo/misc_output.sch
+++ b/pnp/pcb/mobo/misc_output.sch
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ea833d809e5dd22188d02fd10f19b1ffb60b87a79f0d42a748322c941095d7b4
-size 15160
+oid sha256:e45e10cea8c7e0118d3efd5d54025868d70e28c8b96ef4bd59dc2f87ec09a114
+size 15296

--- a/pnp/pcb/mobo/mobo.sch
+++ b/pnp/pcb/mobo/mobo.sch
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:641ddbd721fe493c5eb6e36caebf5866c892cb778a7ec42fe9bd2f405694ac42
-size 34794
+oid sha256:10ec727e191af604dd377315bc2eb19d3ea548de0ca03a181f600b6847349043
+size 35220

--- a/pnp/pcb/mobo/mosfet.sch
+++ b/pnp/pcb/mobo/mosfet.sch
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f29f385cd49b64008e2cbeb8992b1ba2dad24ce22d9952edfd97153a6272e4a
-size 7314
+oid sha256:24c0f3618cbe272070ab163fff2f5d233857d0a2ffb5a057c69ca5bc1177f5a5
+size 7393

--- a/pnp/pcb/mobo/power.sch
+++ b/pnp/pcb/mobo/power.sch
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dea7486603b1739f5d8be61df6d9a229bf6e9cc28a6d2af57c6e45c5731d2145
-size 19361
+oid sha256:a6ae88608014e8d42ada040089ceddc5c4b7a6e55f5ac49849953eef6f2c7c91
+size 20043

--- a/pnp/pcb/mobo/power.sch
+++ b/pnp/pcb/mobo/power.sch
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6ae88608014e8d42ada040089ceddc5c4b7a6e55f5ac49849953eef6f2c7c91
-size 20043
+oid sha256:1e312f5fd10a42d75a5105f5ea448663bf3e14f2f7d06510970f7e99bcb7509e
+size 20175

--- a/pnp/pcb/mobo/usb.sch
+++ b/pnp/pcb/mobo/usb.sch
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b31004850fcf4fdc617b2b85ed9d3c5c69be105939801376b0f9191d7305e596
-size 17361
+oid sha256:78e8e6ba2271cfa408c6735aa6f247f0dc9c811ba2b8411373412047dd84ce2a
+size 17715


### PR DESCRIPTION
Working on the BOM so far. Need confirmation from @G-Pereira that either https://www.digikey.ca/en/products/detail/abracon-llc/ASPI-6045S-120M-T/2343391 
or 
https://www.digikey.ca/en/products/detail/w%C3%BCrth-elektronik/74404064120/4865696
work as alternate parts for the power inductor (L1)?

Also need confirmation on if digikey part ZLDO1117G33DICT-ND will work for U13 and more details about the specs for Y2 before selecting a part from digikey and mouser.

Finally, need confirmation that C33/C34 could use LCSC/JLC part C342635.