### PR TITLE
Updating export 3d files script to be more consistent

### DIFF
--- a/.github/workflows/generate-3d-prints.yaml
+++ b/.github/workflows/generate-3d-prints.yaml
@@ -24,17 +24,25 @@ jobs:
 
     - name: Install FreeCAD Python library
       run:  |
-        sudo add-apt-repository ppa:freecad-maintainers/freecad-stable
-        sudo apt update
-        sudo apt upgrade
         sudo apt install python3
-        sudo apt install freecad
 
     - name: Download repository
       uses: actions/checkout@v2
 
+    - name: Fetch FreeCAD
+      uses: dsaltares/fetch-gh-release-asset@master
+      with:
+        repo: "FreeCAD/FreeCAD"
+        version: "tags/0.19.2"
+        file: "FreeCAD_0.19-24291-Linux-Conda_glibc2.12-x86_64.AppImage"
+        target: "FreeCAD.AppImage"
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Generate 3D files
       run:  |
+        sudo chown runner:docker FreeCAD.AppImage
+        chmod +x FreeCAD.AppImage
+        ./FreeCAD.AppImage --appimage-extract > /dev/null
         cd pnp/cad
         rm -rf 3D-Prints
         mkdir 3D-Prints

--- a/pnp/cad/export-3d-files.py
+++ b/pnp/cad/export-3d-files.py
@@ -2,7 +2,9 @@
 
 import os
 import sys
+import traceback
 from pathlib import Path
+from typing import List
 
 freecad_paths = [
     '/usr/lib/freecad/lib/',  # For CI
@@ -57,7 +59,8 @@ def process_file(cad_file: Path):
         name = name_options[0]
     else:
         # If there is no part number embossed throw error
-        raise ValueError("Part " + cad_file.name + " doesn't have a ShapeString called PN for part number emboss")
+        name = cad_file.name
+        # raise ValueError("Part " + cad_file.name + " doesn't have a ShapeString called PN for part number emboss")
 
     shape = doc.Body.Shape.copy(False)
 
@@ -85,5 +88,19 @@ if __name__ == '__main__':
 
     fdm_path = Path('FDM')
 
+    exceptions: List[Exception] = []
     for f in fdm_path.glob('*.FCStd'):
-        process_file(f)
+        try:
+            process_file(f)
+        except Exception as ex:
+            print(f"An error occurred while processing {str(f)}: ")
+            traceback.print_exc()
+
+            exceptions.append(ex)
+
+    if exceptions:
+        verb = "was" if len(exceptions) == 1 else "were"
+        noun = "exception" if len(exceptions) == 1 else "exceptions"
+        print(f"There {verb} {len(exceptions)} {noun}")
+
+        assert len(exceptions) == 0

--- a/pnp/cad/export-3d-files.py
+++ b/pnp/cad/export-3d-files.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import List
 
 freecad_paths = [
+    '/home/runner/work/index/index/squashfs-root/usr/lib',  # For CI when using AppImage
     '/usr/lib/freecad/lib/',  # For CI
     '/usr/lib/freecad-daily-python3/lib/',  # For Ubuntu
     '/usr/lib64/freecad/lib64/',  # For Fedora
@@ -25,6 +26,9 @@ import MeshPart
 
 print('Python version:')
 print(sys.version)
+
+print('FreeCAD version:')
+print(FreeCAD.Version())
 
 
 def get_shape_placement(print_plane):
@@ -68,7 +72,7 @@ def process_file(cad_file: Path):
         for obj in doc.Objects:
             print(f"- {obj.Label}")
 
-        raise Exception("Body not found in model")
+        raise Exception(f"Body not found in model {cad_file.name}")
 
     body = body[0]
 
@@ -81,7 +85,7 @@ def process_file(cad_file: Path):
         if map_mode in ["ObjectXY", "ObjectXZ", "ObjectYZ"]:
             shape.Placement = get_shape_placement(plane)
         else:
-            print(f"Warning, cannot determine orientation of {name} with map mode {map_mode}")
+            print(f"Warning, cannot determine orientation of {cad_file.name} with map mode {map_mode}")
 
     # Generate STL
     mesh = doc.addObject("Mesh::Feature", "Mesh")

--- a/pnp/cad/export-3d-files.py
+++ b/pnp/cad/export-3d-files.py
@@ -59,10 +59,20 @@ def process_file(cad_file: Path):
         name = name_options[0]
     else:
         # If there is no part number embossed throw error
-        name = cad_file.name
-        # raise ValueError("Part " + cad_file.name + " doesn't have a ShapeString called PN for part number emboss")
+        raise ValueError("Part " + cad_file.name + " doesn't have a ShapeString called PN for part number emboss")
 
-    shape = doc.Body.Shape.copy(False)
+    body = [obj for obj in doc.Objects if obj.Label == "Body"]
+
+    if len(body) == 0:
+        print(f"Cannot find body object. {len(doc.Objects)} objects present")
+        for obj in doc.Objects:
+            print(f"- {obj.Label}")
+
+        raise Exception("Body not found in model")
+
+    body = body[0]
+
+    shape = body.Shape.copy(False)
 
     print_planes = [obj for obj in doc.Objects if obj.Label == "PrintPlane"]
     if print_planes:
@@ -72,7 +82,6 @@ def process_file(cad_file: Path):
             shape.Placement = get_shape_placement(plane)
         else:
             print(f"Warning, cannot determine orientation of {name} with map mode {map_mode}")
-            # return  # Skip this one
 
     # Generate STL
     mesh = doc.addObject("Mesh::Feature", "Mesh")

--- a/pnp/cad/export-3d-files.py
+++ b/pnp/cad/export-3d-files.py
@@ -1,47 +1,89 @@
 #!/usr/bin/python3
-import platform
 
-if platform.system()=="Windows":
-	FREECADPATH = 'c:/Program Files/FreeCAD 0.19/bin/' # For Windows
-else:
-	FREECADPATH = '/usr/lib/freecad-python3/lib/' # For Ubuntu
-	#FREECADPATH = '/usr/lib64/freecad/lib64/' # For Fedora
-
-import sys
 import os
-sys.path.append(FREECADPATH)
+import sys
+from pathlib import Path
+
+freecad_paths = [
+    '/usr/lib/freecad/lib/',  # For CI
+    '/usr/lib/freecad-daily-python3/lib/',  # For Ubuntu
+    '/usr/lib64/freecad/lib64/',  # For Fedora
+    '/Applications/FreeCAD.app/Contents/Resources/lib',  # For Mac OS X
+    'c:/Program Files/FreeCAD 0.18/bin/',  # For Windows
+    'c:/Program Files/FreeCAD 0.19/bin/',  # For Windows
+]
+
+for path in freecad_paths:
+    if os.path.exists(path):
+        print(f"Added possible FreeCAD path: {path}")
+        sys.path.append(path)
+
 import FreeCAD
 import MeshPart
-import Part
 
-# Create output folder if needed
-if not os.path.exists('3D-Prints'):
-    os.makedirs('3D-Prints')
+print('Python version:')
+print(sys.version)
 
-print("Python version:")
-print (sys.version)
 
-for cad_file in os.listdir("FDM"):
-        print("Processing " + cad_file)
+def get_shape_placement(print_plane):
+    map_mode = print_plane.MapMode
+    attachment = print_plane.AttachmentOffset
+    print(print_plane.MapMode, attachment)
 
-        doc = FreeCAD.open('FDM/'+cad_file)
+    if map_mode == "ObjectXY":
+        z_down = FreeCAD.Vector(0, 0, -1)
+    elif map_mode == "ObjectXZ":
+        z_down = FreeCAD.Vector(0, 0, 1)
+    elif map_mode == "ObjectYZ":
+        z_down = FreeCAD.Vector(0, 0, 1)
+    else:
+        raise ValueError(f"Unknown map mode {map_mode}")
 
-        # Getting file name from part number emboss
-        name = ""
-        for obj in doc.Objects:
-            if obj.isDerivedFrom("Part::Part2DObject"):
-                if (obj.Label == "PN"):
-                    name = obj.String
-                    print("PN:"+name)
+    rotation = FreeCAD.Rotation(z_down, attachment.Base)
+    # print(rotation.toEuler())
 
+    return FreeCAD.Placement(FreeCAD.Vector(0, 0, 0), rotation)
+
+
+def process_file(cad_file: Path):
+    print("Processing " + cad_file.name)
+
+    doc = FreeCAD.open(str(cad_file.absolute()))
+
+    # Getting file name from part number emboss
+    name_options = [obj.String for obj in doc.Objects if
+                    obj.isDerivedFrom("Part::Part2DObject") and obj.Label == "PN"]
+    if name_options:
+        name = name_options[0]
+    else:
         # If there is no part number embossed throw error
-        if name == "":
-            raise ValueError("Part " + cad_file + " doesn't have a ShapeString called PN for part number emboss")
+        raise ValueError("Part " + cad_file.name + " doesn't have a ShapeString called PN for part number emboss")
 
-        # Generate STL
-        shape = doc.Body.Shape.copy(False)
-        shape.Placement = doc.Body.getGlobalPlacement()
-        mesh = doc.addObject("Mesh::Feature", "Mesh")
-        mesh.Mesh = MeshPart.meshFromShape(Shape=shape, LinearDeflection=0.01, AngularDeflection=0.025, Relative=False)
-        mesh.Mesh.write("3D-Prints/" + name + ".stl")
-        FreeCAD.closeDocument(doc.Name)
+    shape = doc.Body.Shape.copy(False)
+
+    print_planes = [obj for obj in doc.Objects if obj.Label == "PrintPlane"]
+    if print_planes:
+        plane = print_planes[0]
+        map_mode = plane.MapMode
+        if map_mode in ["ObjectXY", "ObjectXZ", "ObjectYZ"]:
+            shape.Placement = get_shape_placement(plane)
+        else:
+            print(f"Warning, cannot determine orientation of {name} with map mode {map_mode}")
+            # return  # Skip this one
+
+    # Generate STL
+    mesh = doc.addObject("Mesh::Feature", "Mesh")
+    mesh.Mesh = MeshPart.meshFromShape(Shape=shape, LinearDeflection=0.01, AngularDeflection=0.025, Relative=False)
+    mesh.Mesh.write("3D-Prints/" + name + ".stl")
+    FreeCAD.closeDocument(doc.Name)
+
+
+if __name__ == '__main__':
+    # Create output folder if needed
+    output_directory = Path('3D-Prints')
+    output_directory.mkdir(parents=True, exist_ok=True)
+
+    fdm_path = Path('FDM')
+
+    for f in fdm_path.glob('*.FCStd'):
+        process_file(f)


### PR DESCRIPTION
I made the script work on multiple operating systems, at the very least. I'm unsure on some of the rotation stuff, we might need to play around with that.

The action for this will fail because parts don't have embossed names but the idea would be to land this with the failing action and then have Stephen's PR in #318 run against it to see if we need to make further improvements. Testing against index-machines:cad-pn gives all sorts of issues, but I tested it against sphaws:cad-pn and it worked. This also means that the script correctly fails locally for the parts where it couldn't find the Body attribute just like it does on CI.