### PR TITLE
Fix various typos

### DIFF
--- a/feeder/README.md
+++ b/feeder/README.md
@@ -6,7 +6,7 @@ The Index Feeder is a pick and place feeder that is designed to work with 8mm, 1
 
 All versions of the Index Feeder use the same PCB design. This PCB handles communication over RS-485, motor control, positioning, detecting tape runout, and a small UI including two buttons and two LEDs. The microcontroller onboard is the ATMEGA328P, not only for its ubiquitous usage in the hobbyist world (and therefore excellent documentation and accessibility), but also for its ideal specifications for this application.
 
-One of these PCBs gets populated and acts as the left structural panel of the feeder, while a second, unpopulated pcb is purely used as the right structural panel. They're mounted together with 30mm M3 standoffs. The point at which feeders differ to accomodate different sized tape is with the printed tape guides that attach to the PCBs.
+One of these PCBs gets populated and acts as the left structural panel of the feeder, while a second, unpopulated pcb is purely used as the right structural panel. They're mounted together with 30mm M3 standoffs. The point at which feeders differ to accommodate different sized tape is with the printed tape guides that attach to the PCBs.
 
 The tape is indexed forward using an indexing wheel attached to the DC motor. This indexing wheel is actually a PCB with teeth cut along the circumference. This PCB also has small windows cut in it, and has the stokes between these windows plated with gold (ENIG coating). This alternating window/gold plating acts as a form of encoder in conjunction with a VCNT2020 reflective sensor mounted to the PCB. With a bit of signal processing, the output from this sensor can measure how far forward the tape has moved and allow for precise tape positioning.
 

--- a/feeder/pcb/mobo/config.kibot.yaml
+++ b/feeder/pcb/mobo/config.kibot.yaml
@@ -92,7 +92,7 @@ outputs:
       output: Schematic.pdf
 
   - name: 'print_sch'
-    comment: "Pring schematic (PDF, VCNT2020 Variant)"
+    comment: "Print schematic (PDF, VCNT2020 Variant)"
     type: pdf_sch_print
     dir: .
     options:

--- a/lib/cpp/ring/ring.cpp
+++ b/lib/cpp/ring/ring.cpp
@@ -153,7 +153,7 @@ if it returns 2, the recipient picked up, but did not acknowledge
             Serial.println("Received ACK bit");
         }
         else{
-            Serial.println("Did not receieve ack bit");
+            Serial.println("Did not receive ack bit");
             status = 2;
         }
 
@@ -220,7 +220,7 @@ if it returns 1, the communication failed due to timeout.
 
     delay(30);
 
-    //Respond with reciept of response
+    //Respond with receipt of response
     write(_DAT, 0);
     
     while(read(_CLO)){ //waits for clock pulse to start


### PR DESCRIPTION
Found via `codespell -q 3 -S ./pnp/code/firmware_marlin -L ba,dout,ege,ser,tht`