### PR TITLE
build marlin for index mobo with i2c

### DIFF
--- a/.github/workflows/build-marlin-for-index-mobo.yml
+++ b/.github/workflows/build-marlin-for-index-mobo.yml
@@ -1,0 +1,96 @@
+#
+# build-marlin-for-index-mobo.yml
+# Compile Marlin for the Index Mobo
+#
+
+name: build-marlin-for-index-mobo
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  generate-obj:
+    name: Generate Marlin For Index Mobo
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Check out Marlin bugfix-2.0.x
+      uses: actions/checkout@v2
+      with:
+        repository: MarlinFirmware/Marlin
+        ref: bugfix-2.0.x
+        path: Marlin
+        fetch-depth: 1
+        lfs: 'true'
+        submodules: 'true'
+
+    - name: Check out Marlin-Configurations
+      uses: actions/checkout@v2
+      with:
+        repository: MarlinFirmware/Configurations
+        ref: import-2.0.x
+        path: Marlin-Configurations
+
+    - name: Check out Index i2c changes
+      uses: actions/checkout@v2
+      with:
+        repository: stuartpittaway/Marlin
+        ref: M261-M260-enhancement
+        path: Enhancement
+        fetch-depth: 1
+        lfs: 'true'
+        submodules: 'true'
+
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+
+    - name: Select Python 3.7
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7' # Version range or exact version of a Python version to use, using semvers version range syntax.
+        architecture: 'x64' # optional x64 or x86. Defaults to x64 if not specified
+
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+
+    - name: Copy index configuration files
+      run: |
+        cp ./Marlin-Configurations/config/examples/Index/REV_03/Configuration.h ./Marlin/Marlin/
+        cp ./Marlin-Configurations/config/examples/Index/REV_03/Configuration_adv.h ./Marlin/Marlin/
+
+    - name: Patch i2c M260 command
+      run: |
+        cp ./Enhancement/Marlin/src/feature/twibus.cpp ./Marlin/Marlin/src/feature/
+        cp ./Enhancement/Marlin/src/feature/twibus.h ./Marlin/Marlin/src/feature/
+        cp ./Enhancement/Marlin/src/gcode/feature/i2c/M260_M261.cpp ./Marlin/Marlin/src/gcode/feature/i2c/
+
+    - name: Build code for Marlin
+      run: pio run --project-dir=./Marlin --project-conf=./Marlin/platformio.ini -e Index_Mobo_Rev03
+      env:
+        PLATFORMIO_BUILD_FLAGS: -DEXPERIMENTAL_I2CBUS
+
+    - name: Get current date
+      id: date
+      run: echo "dt=$(date +'%Y-%m-%d-%H-%M')" >> $GITHUB_ENV
+
+    - name: Rename firmware file using todays date
+      run: mv ./Marlin/.pio/build/Index_Mobo_Rev03/firmware.bin ./Marlin/.pio/build/Index_Mobo_Rev03/index_mobo_v3_marlin_firmware_${{ env.dt }}.bin
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: Index_Mobo_Rev03_Marlin_Firmware
+        path: ./Marlin/.pio/build/Index_Mobo_Rev03/*.bin


### PR DESCRIPTION
Compiles Marlin bugfix branch with the correct Index configuration and patched to support i2c reading.  

Creates an artefact file containing output, which can then be used with STM32CubeProgrammer software to program the Index Mobo.

This GITHUB action is manually triggered as required.