### PR TITLE
Add kitspace manifest (but don't allow any PCB service links for mobo)

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -6,7 +6,7 @@ multi:
       type: kicad
       pcb: pnp/pcb/mobo/mobo.kicad_pcb
     bom: pnp/pcb/mobo/mobo.kicad_pcb
-    pcb-services: [jlcpcb]
+    pcb-services: []
     readme: README.md
     site: https://indexmachines.io/
 

--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,6 +1,7 @@
 multi:
   index-mobo:
     summary: Index pick and place machine motherboard
+    color: black
     eda:
       type: kicad
       pcb: pnp/pcb/mobo/mobo.kicad_pcb
@@ -11,6 +12,7 @@ multi:
 
   index-ringLight:
     summary: Index pick and place machine ring light
+    color: black
     eda:
       type: kicad
       pcb: pnp/pcb/ringLight/ringLight.kicad_pcb
@@ -20,6 +22,7 @@ multi:
 
   index-feederFloor:
     summary: Index pick and place machine feeder floor
+    color: black
     eda:
       type: kicad
       pcb: feeder/pcb/feederFloor/feederFloor.kicad_pcb
@@ -29,6 +32,7 @@ multi:
 
   index-indexingWheel:
     summary: Index pick and place machine feeder indexing wheel
+    color: black
     eda:
       type: kicad
       pcb: feeder/pcb/indexingWheel/indexingWheel.kicad_pcb
@@ -38,6 +42,7 @@ multi:
 
   index-feeder-mobo:
     summary: Index pick and place machine feeder motherboard
+    color: black
     eda:
       type: kicad
       pcb: feeder/pcb/mobo/mobo.kicad_pcb

--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,19 @@
+multi:
+  index-mobo:
+    summary: Index pick and place machine motherboard
+    eda:
+      type: kicad
+      pcb: pnp/pcb/mobo/mobo.kicad_pcb
+    bom: pnp/pcb/mobo/mobo.kicad_pcb
+    pcb-services: [jlcpcb]
+    readme: README.md
+    site: https://indexmachines.io/
+
+  index-ringLight:
+    summary: Index pick and place machine ring light
+    eda:
+      type: kicad
+      pcb: pnp/pcb/ringLight/ringLight.kicad_pcb
+    bom: pnp/pcb/ringLight/ringLight.kicad_pcb
+    readme: README.md
+    site: https://indexmachines.io/

--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -17,3 +17,30 @@ multi:
     bom: pnp/pcb/ringLight/ringLight.kicad_pcb
     readme: README.md
     site: https://indexmachines.io/
+
+  index-feederFloor:
+    summary: Index pick and place machine feeder floor
+    eda:
+      type: kicad
+      pcb: feeder/pcb/feederFloor/feederFloor.kicad_pcb
+    bom: feeder/pcb/feederFloor/feederFloor.kicad_pcb
+    readme: README.md
+    site: https://indexmachines.io/
+
+  index-indexingWheel:
+    summary: Index pick and place machine feeder indexing wheel
+    eda:
+      type: kicad
+      pcb: feeder/pcb/indexingWheel/indexingWheel.kicad_pcb
+    bom: feeder/pcb/indexingWheel/indexingWheel.kicad_pcb
+    readme: README.md
+    site: https://indexmachines.io/
+
+  index-feeder-mobo:
+    summary: Index pick and place machine feeder motherboard
+    eda:
+      type: kicad
+      pcb: feeder/pcb/mobo/mobo.kicad_pcb
+    bom: feeder/pcb/mobo/mobo.kicad_pcb
+    readme: README.md
+    site: https://indexmachines.io/


### PR DESCRIPTION
Following on from discussions in #39, around impedance calculations only being verified to work for JLCPCB, I added the ability to filter the listed PCB services on Kitspace pages. It's done through a new field in the kitspace.yaml  (`pcb-services:`). I set it the yaml here to restrict the links for the Index mobo to be for JLCPCB only. 

Here is a preview: http://preview-index.preview.kitspace.org/ 

I left the PCB Shopper comparison link in there for now. A user would have to download the Gerber files and upload them to a service to have it made. So I would say, they would need to know what they are doing more so than with the direct link. I'm interested in your opinion on that though (@G-Pereira), if you would prefer not to have that link too. 