### PR TITLE
tooltip shortcode test

### DIFF
--- a/doc/.markdownlint.json
+++ b/doc/.markdownlint.json
@@ -1,4 +1,5 @@
 {
   "MD013": false,
-  "MD022": { "lines_below": 0}
+  "MD022": { "lines_below": 0},
+  "MD033": false
 }

--- a/doc/content/en/docs/mechanical-assembly/left-side/index.md
+++ b/doc/content/en/docs/mechanical-assembly/left-side/index.md
@@ -15,48 +15,48 @@ Alright, time to get into the build! First, we're going to build up the left sid
 
 {{< container-image path="images/IMG_20210826_150501-web.jpg" alt="Belt Tension Arm Parts" >}}
 
-1. Insert an M3 Hex Nut into the back of a Belt Tension Arm (FDM-0037).
+1. Insert an M3 Hex Nut into the back of a {{<tooltip>}}Belt Tension Arm.{{<definition>}}FDM-0037{{</definition>}}{{</tooltip>}}
   {{< container-image path="images/IMG_20210826_150533-web.jpg" alt="Inserted M3 Hex Nut" >}}
 
-2. Insert the M3x16mm Machine Screw through the front hole in the Belt Tension Arm and then tighten.
+2. Insert the M3x16mm Machine Screw through the front hole in the {{<tooltip>}}Belt Tension Arm.{{<definition>}}FDM-0037{{</definition>}}{{</tooltip>}} and then tighten.
 3. Thread an M3 Cap Nut on the end of the M3x16mm Machine Screw.
   {{< container-image path="images/IMG_20210826_150638-web.jpg" alt="M3 Screw, M3 Nut, and M3 Cap Nut installed" >}}
 
-4. Insert the M5x25mm Machine Screw through the hole in the top of the Belt Tension Arm so that it passes through a GT2 Pulley Idler.
-5. Add an M5 Nyloc Hex Nut on the bottom of the Belt Tension Arm and tighten. Make sure the idler can still spin freely.
+4. Insert the M5x25mm Machine Screw through the hole in the top of the {{<tooltip>}}Belt Tension Arm{{<definition>}}FDM-0037{{</definition>}}{{</tooltip>}} so that it passes through a GT2 Pulley Idler.
+5. Add an M5 Nyloc Hex Nut on the bottom of the {{<tooltip>}}Belt Tension Arm{{<definition>}}FDM-0037{{</definition>}}{{</tooltip>}} and tighten. Make sure the idler can still spin freely.
   {{< container-image path="images/IMG_20210826_150728-webreverse.jpg" alt="M5 Screw, GT2 Idler Pulley, and M5 Nut installed" >}}
 
-6. Insert the M5 Nyloc Hex Nut into the recess for a hex nut on the bottom of one of the idler mount arms on the Front Left Leg (FDM-0001).
-7. Insert completed Belt Tension Arm assembly between the arms on the front leg, with the screw head of the M5x25mm facing up.
-8. Insert the M5x40mm Machine Screw through the hole in the top so that it passes through the Belt Tension Arm and tighten into the M5 Nyloc Hex Nut. Do not overtighten, and ensure you can still pivot the tension arm.
+6. Insert the M5 Nyloc Hex Nut into the recess for a hex nut on the bottom of one of the idler mount arms on the {{<tooltip>}}Front Left Leg. {{<definition>}}FDM-0001{{</definition>}}{{</tooltip>}}
+7. Insert completed {{<tooltip>}}Belt Tension Arm{{<definition>}}FDM-0037{{</definition>}}{{</tooltip>}} assembly between the arms on the front leg, with the screw head of the M5x25mm facing up.
+8. Insert the M5x40mm Machine Screw through the hole in the top so that it passes through the {{<tooltip>}}Belt Tension Arm{{<definition>}}FDM-0037{{</definition>}}{{</tooltip>}} and tighten into the M5 Nyloc Hex Nut. Do not over-tighten, and ensure you can still pivot the tension arm.
   {{< container-image path="images/IMG_20210826_151445-web.jpg" alt="Idler and Belt Tension Arm installed on Leg" >}}
 
 ## Assembly
 
-9. Take the Back Left Leg (FDM-0003) and insert the v-slot extrusions into the two square holes designed to take this part. Ensure that the extrusion comes to the end of the holes in which they're inserted. If you have a hard time getting the extrusion into the slots, gently slide them into place using some taps from a mallet.
+9. Take the {{<tooltip>}}Back Left Leg{{<definition>}}FDM-0003{{</definition>}}{{</tooltip>}} and insert the v-slot extrusions into the two square holes designed to take this part. Ensure that the extrusion comes to the end of the holes in which they're inserted. If you have a hard time getting the extrusion into the slots, gently slide them into place using some taps from a mallet.
   {{< container-image path="images/extrusion_fully_inserted.png" >}}
 
-10. Take the front left leg and place it onto two v-slot extrusions at the end opposite the back leg. Your progress should look like the image below.
+10. Take the {{<tooltip>}}Front Left Leg{{<definition>}}FDM-0001{{</definition>}}{{</tooltip>}} and place it onto two v-slot extrusions at the end opposite the {{<tooltip>}}Back Left Leg{{<definition>}}FDM-0003{{</definition>}}{{</tooltip>}} Your progress should look like the image below.
   {{< container-image path="images/before_screws.png" >}}
 
 11. On the top rail, drop in and position a slot nut underneath the hole in the top of each leg and screw a M5x10mm machine screw into the nut.
   {{< container-image path="images/top_screws.png" >}}
 
-12. On the bottom rail, the outer side (shown above) has three exposed holes for machine screws (one on the back leg, two on the front leg). For each, drop in and position a slot nut under it and screw a M5x10mm machine screw into it.
+12. On the bottom rail, the outer side (shown above) has three exposed holes for machine screws (one on the {{<tooltip>}}Back Left Leg,{{<definition>}}FDM-0003{{</definition>}}{{</tooltip>}} two on the {{<tooltip>}}Front Left Leg).{{<definition>}}FDM-0001{{</definition>}}{{</tooltip>}} For each, drop in and position a slot nut under it and screw a M5x10mm machine screw into it.
   {{< container-image path="images/outer_screws.png" >}}
 
-13. On the bottom rail, the inner side has one exposed hole for a machine screw on the back leg. Drop in and position a slot nut under it and screw a M5x10mm machine screw into it.
+13. On the bottom rail, the inner side has one exposed hole for a machine screw on the {{<tooltip>}}Back Left Leg.{{<definition>}}FDM-0003{{</definition>}}{{</tooltip>}} Drop in and position a slot nut under it and screw a M5x10mm machine screw into it.
   {{< container-image path="images/inner_screws.png" >}}
 
-14. Next, attach the GT2 Timing Pulley to the spindle of a NEMA17 stepper motor. Tighten one of the grub screws on the pulley into the flat spot on the spindle. Then mount the NEMA17 stepper motor to the back left leg. Attach it using four M3x8mm screws, ensuring that the connector is facing inwards towards the zip tie loops as dictated in the picture.
+14. Next, attach the GT2 Timing Pulley to the spindle of a NEMA17 stepper motor. Tighten one of the grub screws on the pulley into the flat spot on the spindle. Then mount the NEMA17 stepper motor to the {{<tooltip>}}Back Left Leg.{{<definition>}}FDM-0003{{</definition>}}{{</tooltip>}} Attach it using four M3x8mm screws, ensuring that the connector is facing inwards towards the zip tie loops as dictated in the picture.
   {{< container-image path="images/Screen Shot 2022-02-04 at 2.23.07 PM.PNG" >}}
 
-15. Mount one of the three limit switches to the front left leg as shown in the image. Use two M3x8mm screws and tap them directly into the print.
+15. Mount one of the three limit switches to the {{<tooltip>}}Front Left Leg{{<definition>}}FDM-0001{{</definition>}}{{</tooltip>}} as shown in the image. Use two M3x8mm screws and tap them directly into the print.
   {{< container-image path="images/Screen Shot 2022-02-04 at 2.40.17 PM.PNG" >}}
 
-16. Next, we'll mount the Frame Umbilical Mount (FDM-0007). Using two M5x25mm screws, attach it to the front left leg as shown, threading directly into the part. 
+16. Next, we'll mount the {{<tooltip>}}Frame Umbilical Mount.{{<definition>}}FDM-0007{{</definition>}}{{</tooltip>}} Using two M5x25mm screws, attach it to the front left leg as shown, threading directly into the part.
   {{< container-image path="images/Screen Shot 2022-02-04 at 2.43.16 PM.PNG" >}}
 
-17. Lastly, we'll assemble the umbilical swivel. This part helps keep the X gantry umbilical suspended over the build area. The two parts fit together as shown below, and are secured in place with a M5x40mm bolt and an M5 nut. Tighten so there's no play in the fit, but the two parts can swivel easily. Set it aside for now.
+17. Lastly, we'll assemble the umbilical swivel. {{<tooltip>}}Swivel Part 1 and Swivel Part 2{{<definition>}}FDM-0046 and FDM-0047{{</definition>}}{{</tooltip>}} fit together as shown below, and are secured in place with a M5x40mm bolt and an M5 nut. Tighten so there's no play in the fit, but the two parts can swivel easily. This part helps keep the X gantry umbilical suspended over the build area. Set it aside for now.
 
 {{< container-image path="images/Screen Shot 2022-02-04 at 2.45.39 PM.PNG" >}}

--- a/doc/layouts/shortcodes/definition.html
+++ b/doc/layouts/shortcodes/definition.html
@@ -1,0 +1,1 @@
+<span class="definition">{{ .Inner }}</span>

--- a/doc/layouts/shortcodes/tooltip.html
+++ b/doc/layouts/shortcodes/tooltip.html
@@ -1,0 +1,32 @@
+<style>
+    .definition {
+        visibility: hidden;
+        width: 120px;
+        background-color: #555;
+        color: #fff;
+        text-align: center;
+        border-radius: 6px;
+        padding: 5px 0;
+        position: absolute;
+        z-index: 1;
+        bottom: 125%;
+        left: 50%;
+        margin-left: -60px;
+        opacity: 0;
+        transition: opacity 0.3s;
+    }
+
+    .term {
+        position: relative;
+        display: inline-block;
+        border-bottom: 1px dotted black;
+    }
+
+    .term:hover .definition {
+        visibility: visible;
+        opacity: 1;
+    }
+    </style>
+    <span class="term">
+        {{ .Inner }}
+    </span>


### PR DESCRIPTION
@sphawes I tried out a little shortcode I found [here](https://www.starfallprojects.co.uk/blog/hugo-tooltip-shortcode/#conclusion) to clean up and standardize putting CAD file part numbers into the docs. I only changed the left-side assembly page as a first draft to see how it would look. Thoughts? 

(My understanding is that this kind of tooltip is bad for screen readers and accessibility, if you care).

Pros: 
1. Makes it easy to include the serial number for each CAD piece everywhere in the docs without cluttering them up

Cons:
1. Makes the docs more complicated to write, and maybe less readable?

(this pull request is to pull this draft into my other work, so it will not go live yet even if you approve the pull request)