### PR TITLE
Update ringLight.kicad_sch

### DIFF
--- a/pnp/pcb/ringLight/ringLight.kicad_sch
+++ b/pnp/pcb/ringLight/ringLight.kicad_sch
@@ -15,7 +15,7 @@
       (property "Reference" "U" (id 0) (at -2.54 3.81 0)
         (effects (font (size 1.27 1.27)))
       )
-      (property "Value" "74AHCT1G32" (id 1) (at 0 -3.81 0)
+      (property "Value" "74AHCT1G32DCKRG4" (id 1) (at 0 -3.81 0)
         (effects (font (size 1.27 1.27)))
       )
       (property "Footprint" "" (id 2) (at 0 0 0)


### PR DESCRIPTION
Replaced the P/N with the correct full P/N.


One note though:

JLCPCB doesn't support the correct part number for the footprint used (74AHCT1G32DCKRG4) but does have the sot23 alternative (74AHCT1G32DBVRG4).
Maybe switching to the other reference would help with assembly? I did modify the pcb for that, and needed to change the 0805 footprints to 0603s to have it fit. But if that is the prefered solution, I can upload the modified design for that too 